### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,9 @@ version = project.findProperty("newVersion") ?: project.findProperty("defaultVer
 repositories {
 	jcenter()
 	maven { url "http://rubygems-proxy.torquebox.org/releases/" }
-	maven { url "http://repo.spring.io/libs-snapshot-local" }
-	maven { url "http://repo.spring.io/libs-milestone-local" }
-	maven { url "http://repo.spring.io/libs-release-local" }
+	maven { url "https://repo.spring.io/libs-snapshot-local" }
+	maven { url "https://repo.spring.io/libs-milestone-local" }
+	maven { url "https://repo.spring.io/libs-release-local" }
 }
 
 apply plugin: "com.github.jruby-gradle.base"

--- a/tools/cf-helper.sh
+++ b/tools/cf-helper.sh
@@ -34,7 +34,7 @@ CF_DEFAULT_ORG="${CF_DEFAULT_ORG:-pcfdev-org}"
 export CF_DEFAULT_SPACE
 CF_DEFAULT_SPACE="${CF_DEFAULT_SPACE:-cloudpipelines-test}"
 export ARTIFACTORY_URL
-ARTIFACTORY_URL="${ARTIFACTORY_URL:-http://repo.spring.io/libs-milestone}"
+ARTIFACTORY_URL="${ARTIFACTORY_URL:-https://repo.spring.io/libs-milestone}"
 export EUREKA_MEMORY
 EUREKA_MEMORY="${EUREKA_MEMORY:-1024m}"
 

--- a/tools/deploy-infra.sh
+++ b/tools/deploy-infra.sh
@@ -7,7 +7,7 @@
 # Examples:
 #   $ ./tools/deploy-infra.sh
 #   $ ./tools/deploy-infra.sh ../repos/pivotal/
-#   $ ARTIFACTORY_URL="http://192.168.99.100:8081/artifactory/libs-release-local" ./tools/deploy-infra.sh
+#   $ ARTIFACTORY_URL="https://192.168.99.100:8081/artifactory/libs-release-local" ./tools/deploy-infra.sh
 #
 
 set -o errexit
@@ -23,7 +23,7 @@ if [[ -z "${POTENTIAL_DOCKER_HOST}" ]]; then
     POTENTIAL_DOCKER_HOST="localhost"
 fi
 
-ARTIFACTORY_URL="${ARTIFACTORY_URL:-http://admin:password@${POTENTIAL_DOCKER_HOST}:8081/artifactory/libs-release-local}"
+ARTIFACTORY_URL="${ARTIFACTORY_URL:-https://admin:password@${POTENTIAL_DOCKER_HOST}:8081/artifactory/libs-release-local}"
 ARTIFACTORY_ID="${ARTIFACTORY_ID:-artifactory-local}"
 
 function deploy_project {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://rubygems-proxy.torquebox.org/releases/ (200) could not be migrated:  
   ([https](https://rubygems-proxy.torquebox.org/releases/) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://192.168.99.100:8081/artifactory/libs-release-local (ConnectTimeoutException) migrated to:  
  https://192.168.99.100:8081/artifactory/libs-release-local ([https](https://192.168.99.100:8081/artifactory/libs-release-local) result ConnectTimeoutException).
* http://admin:password@ (UnknownHostException) migrated to:  
  https://admin:password@ ([https](https://admin:password@) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://repo.spring.io/libs-milestone migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).
* http://repo.spring.io/libs-milestone-local migrated to:  
  https://repo.spring.io/libs-milestone-local ([https](https://repo.spring.io/libs-milestone-local) result 302).
* http://repo.spring.io/libs-release-local migrated to:  
  https://repo.spring.io/libs-release-local ([https](https://repo.spring.io/libs-release-local) result 302).
* http://repo.spring.io/libs-snapshot-local migrated to:  
  https://repo.spring.io/libs-snapshot-local ([https](https://repo.spring.io/libs-snapshot-local) result 302).